### PR TITLE
Add MCP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ This application provides integrated tool use capabilities for enhanced AI inter
 - Tool use only available for Anthropic models
 - Limited to web search and code execution tools
 
+### MCP Integration
+
+The app can connect to an external **Model Control Plane (MCP)** server to fetch additional tools.
+Configure the server URL and token in the new **MCP** tab of the settings dialog.
+Press **Connect** to perform a JSON-RPC 2.0 handshake where the client sends its
+capabilities and receives lists of resources, prompts, and tools. Example URL:
+`https://mcp.example.com/rpc`.
+After connecting, MCP tools appear next to built-in ones in the message input and
+can be toggled on or off per message.
+
 ### File Upload & Attachment System
 
 This application provides comprehensive file upload capabilities with intelligent handling:

--- a/components/chat/message-input.js
+++ b/components/chat/message-input.js
@@ -142,20 +142,30 @@ export default function MessageInput({ onSendMessage, onCancelMessage, isLoading
   const currentProvider = useSettingsStore(state => state.currentProvider);
   const providers = useSettingsStore(state => state.providers);
   const toggleTool = useSettingsStore(state => state.toggleTool);
+  const mcpTools = useSettingsStore(state => state.mcp.availableTools);
+  const toggleMcpTool = useSettingsStore(state => state.toggleMcpTool);
   
   // Get available tools for current provider
-  const availableTools = useMemo(() => {
+  const providerTools = useMemo(() => {
     const provider = providers[currentProvider];
     return provider?.tools || [];
   }, [providers, currentProvider]);
+
+  const availableTools = useMemo(() => {
+    return [...providerTools, ...(mcpTools || [])];
+  }, [providerTools, mcpTools]);
 
   // --- Derived State ---
   const isDisabled = formDisabled || isProcessingFiles || isLoading || isStreaming; // Combine all disabled conditions
   
   // --- Tool Selection Handlers ---
   const handleToggleTool = useCallback((toolId) => {
-    toggleTool(currentProvider, toolId);
-  }, [toggleTool, currentProvider]);
+    if (providerTools.some(t => t.id === toolId)) {
+      toggleTool(currentProvider, toolId);
+    } else {
+      toggleMcpTool(toolId);
+    }
+  }, [toggleTool, toggleMcpTool, currentProvider, providerTools]);
 
   // --- File Dropzone ---
   const { getRootProps, getInputProps, isDragActive, open } = useDropzone({

--- a/components/settings/mcp-settings.js
+++ b/components/settings/mcp-settings.js
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useSettingsStore } from '@/lib/store/settings-store';
+import MCPClient from '@/lib/api/mcp-client';
+
+export default function MCPSettings() {
+  const {
+    mcp,
+    setMcpServerUrl,
+    setMcpAuthToken,
+    setMcpAvailableTools,
+  } = useSettingsStore();
+
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  const handleConnect = async () => {
+    setIsConnecting(true);
+    try {
+      const client = new MCPClient(mcp.mcpServerUrl, mcp.authToken);
+      const result = await client.initialize({ host: 'chatgpt-clone' });
+      const tools = (result.tools || []).map(t => ({ ...t, enabled: false, source: 'mcp' }));
+      setMcpAvailableTools(tools);
+    } catch (err) {
+      console.error('MCP connect failed:', err);
+      alert('Failed to connect to MCP server');
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const handleDisconnect = () => {
+    setMcpAvailableTools([]);
+  };
+
+  const isConnected = mcp.availableTools.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="settings-item">
+        <Label htmlFor="mcp-url">Server URL</Label>
+        <Input
+          id="mcp-url"
+          value={mcp.mcpServerUrl}
+          onChange={(e) => setMcpServerUrl(e.target.value)}
+          placeholder="https://mcp.example.com/rpc"
+        />
+      </div>
+      <div className="settings-item">
+        <Label htmlFor="mcp-token">Auth Token</Label>
+        <Input
+          id="mcp-token"
+          type="password"
+          value={mcp.authToken}
+          onChange={(e) => setMcpAuthToken(e.target.value)}
+        />
+      </div>
+      <Button type="button" onClick={isConnected ? handleDisconnect : handleConnect} disabled={isConnecting}>
+        {isConnected ? 'Disconnect' : 'Connect'}
+      </Button>
+    </div>
+  );
+}

--- a/components/settings/user-settings.js
+++ b/components/settings/user-settings.js
@@ -12,6 +12,7 @@ import {
 import GeneralSettings from './general-settings';
 import ModelSettings from './model-settings';
 import DataSettings from './data-settings';
+import MCPSettings from './mcp-settings';
 import { cn } from '@/lib/utils';
 
 export function UserSettings({ open, onClose }) {
@@ -36,6 +37,7 @@ export function UserSettings({ open, onClose }) {
           <TabsList className="settings-tabs-list">
             <TabsTrigger value="general" className="settings-tabs-trigger">General</TabsTrigger>
             <TabsTrigger value="models" className="settings-tabs-trigger">Models</TabsTrigger>
+            <TabsTrigger value="mcp" className="settings-tabs-trigger">MCP</TabsTrigger>
             <TabsTrigger value="data" className="settings-tabs-trigger">Data Management</TabsTrigger>
           </TabsList>
 
@@ -49,6 +51,10 @@ export function UserSettings({ open, onClose }) {
 
           <TabsContent value="data" className="settings-tabs-content">
             <DataSettings onClose={onClose} />
+          </TabsContent>
+
+          <TabsContent value="mcp" className="settings-tabs-content">
+            <MCPSettings />
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/lib/api/api-service.js
+++ b/lib/api/api-service.js
@@ -71,6 +71,15 @@ export class OpenAIService extends ApiService {
             type: 'code_interpreter',
             container: tool.config?.container || { type: 'auto' },
           };
+        } else if (tool.source === 'mcp') {
+          return {
+            type: 'function',
+            function: {
+              name: tool.id,
+              description: tool.description || '',
+              parameters: tool.parameters || {},
+            },
+          };
         }
         return null;
       }).filter(Boolean);
@@ -237,6 +246,13 @@ export class AnthropicService extends ApiService {
               type: 'code_execution_20250522',
               name: 'code_execution',
             });
+          } else if (tool.source === 'mcp') {
+            tools.push({
+              type: 'tool_use',
+              name: tool.id,
+              description: tool.description || '',
+              input_schema: tool.parameters || {},
+            });
           }
         }
         
@@ -334,6 +350,17 @@ export class GoogleAIService extends ApiService {
         ...(systemInstruction && { systemInstruction }),
         stream: shouldStream,
       };
+
+      const mcpFunctions = enabledTools
+        .filter(t => t.source === 'mcp')
+        .map(t => ({
+          name: t.id,
+          description: t.description || '',
+          parameters: t.parameters || {},
+        }));
+      if (mcpFunctions.length > 0) {
+        requestBody.tools = { functionDeclarations: mcpFunctions };
+      }
 
       const response = await fetch(this.baseUrl, {
         method: 'POST',

--- a/lib/api/mcp-client.js
+++ b/lib/api/mcp-client.js
@@ -1,0 +1,54 @@
+'use client';
+
+export default class MCPClient {
+  constructor(serverUrl = '', authToken = '') {
+    this.serverUrl = serverUrl;
+    this.authToken = authToken;
+    this.idCounter = 1;
+    this.resources = [];
+    this.prompts = [];
+    this.tools = [];
+  }
+
+  setConnection(serverUrl, authToken) {
+    this.serverUrl = serverUrl;
+    this.authToken = authToken;
+  }
+
+  async _sendRpcRequest(method, params = {}) {
+    if (!this.serverUrl) {
+      throw new Error('MCP server URL is not set');
+    }
+    const body = {
+      jsonrpc: '2.0',
+      method,
+      params,
+      id: this.idCounter++,
+    };
+    const response = await fetch(this.serverUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await response.json();
+    if (data.error) {
+      throw new Error(data.error.message || 'MCP RPC error');
+    }
+    return data.result;
+  }
+
+  async initialize(capabilities = {}) {
+    const result = await this._sendRpcRequest('initialize', { capabilities });
+    this.resources = result.resources || [];
+    this.prompts = result.prompts || [];
+    this.tools = result.tools || [];
+    return result;
+  }
+
+  async callTool(toolId, params = {}) {
+    return this._sendRpcRequest('callTool', { toolId, params });
+  }
+}

--- a/lib/store/chat-store.js
+++ b/lib/store/chat-store.js
@@ -292,8 +292,10 @@ export const useChatStore = create(
             // Create the appropriate service
             const apiService = createApiService(currentProvider, apiKey);
 
-            // Get enabled tools for current provider
-            const enabledTools = settings.getEnabledTools(currentProvider);
+            // Get enabled tools from provider and MCP
+            const providerTools = settings.getEnabledTools(currentProvider);
+            const mcpTools = settings.getEnabledMcpTools();
+            const enabledTools = [...providerTools, ...mcpTools];
 
             // Call chatCompletion
             const apiResponse = await apiService.chatCompletion(
@@ -474,7 +476,9 @@ export const useChatStore = create(
 
             // --- 7. Make API Call ---
             const apiService = createApiService(currentProvider, apiKey);
-            const enabledTools = settings.getEnabledTools(currentProvider);
+            const providerTools = settings.getEnabledTools(currentProvider);
+            const mcpTools = settings.getEnabledMcpTools();
+            const enabledTools = [...providerTools, ...mcpTools];
 
             const apiResponse = await apiService.chatCompletion(
               messagesForApi,
@@ -683,8 +687,10 @@ export const useChatStore = create(
             // --- 5. Make API Call ---
             const apiService = createApiService(currentProvider, apiKey);
 
-            // Get enabled tools for current provider
-            const enabledTools = settings.getEnabledTools(currentProvider);
+            // Get enabled tools for current provider and MCP
+            const providerTools = settings.getEnabledTools(currentProvider);
+            const mcpTools = settings.getEnabledMcpTools();
+            const enabledTools = [...providerTools, ...mcpTools];
 
             const apiResponse = await apiService.chatCompletion(
               messagesForApi,

--- a/lib/store/settings-store.js
+++ b/lib/store/settings-store.js
@@ -81,9 +81,17 @@ const defaultProviders = {
   },
 };
 
+// Default MCP settings
+const defaultMcpSettings = {
+  mcpServerUrl: '',
+  authToken: '',
+  availableTools: [],
+};
+
 // Default settings
 const defaultSettings = {
   providers: defaultProviders,
+  mcp: defaultMcpSettings,
   currentProvider: 'openai',
   currentModel: 'chatgpt-4o-latest',
   theme: 'dark',
@@ -196,6 +204,46 @@ export const useSettingsStore = create((set, get) => ({
       providers: updatedProviders,
     }));
   },
+
+  // ==== MCP Settings ====
+  setMcpServerUrl: (url) => {
+    set({ mcp: { ...get().mcp, mcpServerUrl: url } });
+    localStorage.setItem('ai-settings', JSON.stringify({
+      ...get(),
+      mcp: { ...get().mcp, mcpServerUrl: url },
+    }));
+  },
+
+  setMcpAuthToken: (token) => {
+    set({ mcp: { ...get().mcp, authToken: token } });
+    localStorage.setItem('ai-settings', JSON.stringify({
+      ...get(),
+      mcp: { ...get().mcp, authToken: token },
+    }));
+  },
+
+  setMcpAvailableTools: (tools) => {
+    set({ mcp: { ...get().mcp, availableTools: tools } });
+    localStorage.setItem('ai-settings', JSON.stringify({
+      ...get(),
+      mcp: { ...get().mcp, availableTools: tools },
+    }));
+  },
+
+  toggleMcpTool: (toolId) => {
+    const tools = get().mcp.availableTools.map(t =>
+      t.id === toolId ? { ...t, enabled: !t.enabled } : t
+    );
+    set({ mcp: { ...get().mcp, availableTools: tools } });
+    localStorage.setItem('ai-settings', JSON.stringify({
+      ...get(),
+      mcp: { ...get().mcp, availableTools: tools },
+    }));
+  },
+
+  getEnabledMcpTools: () => {
+    return get().mcp.availableTools.filter(t => t.enabled);
+  },
   
   getEnabledTools: (providerId) => {
     const provider = get().providers[providerId];
@@ -277,6 +325,10 @@ export const useSettingsStore = create((set, get) => ({
       const mergedSettings = {
         ...defaultSettings,
         ...savedSettings,
+        mcp: {
+          ...defaultMcpSettings,
+          ...(savedSettings.mcp || {}),
+        },
         providers: { // Deep merge providers to keep default models/structure
           ...Object.keys(defaultProviders).reduce((acc, providerId) => {
             const savedProvider = savedSettings.providers?.[providerId];


### PR DESCRIPTION
## Summary
- implement MCP JSON-RPC client
- store MCP configuration and tools in settings store
- add MCP tab in settings with connection UI
- expose MCP tools in message input and send them to providers
- translate MCP tools for OpenAI, Anthropic and Google providers
- document MCP usage in README

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684b5f01d37083308cc11abc4cbc81a0